### PR TITLE
Add Dockerfile with container description and tests for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python # support for pip, used to install ncclient
+sudo: required
+services:
+  - docker
+before_install:
+  - pip install ncclient
+script:
+  - docker build -t openyuma .
+  - docker run -d -p 8300:830 -p 2200:22 --name openyuma openyuma
+  - while ! docker logs openyuma | grep 'Running netconfd server'; do sleep 1; done
+  - sleep 5
+  - python -c "from ncclient import manager; m = manager.connect(host='127.0.0.1', port=8300, username='admin', password='admin', hostkey_verify=False); print(m.get_config(source='running'))"
+  - docker stop openyuma

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:14.04
+
+# install required packages
+ENV DEBIAN_FRONTEND noninteractive
+RUN ["apt-get", "update"]
+RUN ["apt-get", "install", "-y", "git", "autoconf", "gcc", "libtool", "libxml2-dev", "libssl-dev", "make", "libncurses5-dev", "libssh2-1-dev", "openssh-server"]
+
+# setup admin user that openyuma will use
+RUN set -x -e; \
+    mkdir /var/run/sshd; \
+    adduser --gecos '' --disabled-password admin; \
+    echo "admin:admin" | chpasswd
+
+# copy and build openyuma, setup the container to start it by default
+COPY . /usr/src/OpenYuma
+WORKDIR /usr/src/OpenYuma
+RUN set -x -e; \
+    make; \
+    sudo make install; \
+    touch /tmp/startup-cfg.xml; \
+    printf 'Port 830\nSubsystem netconf "/usr/sbin/netconf-subsystem --ncxserver-sockname=830@/tmp/ncxserver.sock"\n' >> /etc/ssh/sshd_config; \
+    printf '#!/bin/bash\nset -e -x\n/usr/sbin/netconfd --startup=/tmp/startup-cfg.xml --superuser=admin &\nsleep 1\n/usr/sbin/sshd -D &\nwait\nkill %%\n' > /root/start.sh; \
+    chmod 0755 /root/start.sh
+CMD ["/root/start.sh"]
+
+# finishing touches
+EXPOSE 22
+EXPOSE 830

--- a/README.md
+++ b/README.md
@@ -1,4 +1,30 @@
-netconf
-=======
+OpenYuma
+========
 
-Fork of the defacto standard Yuma project since it went proprietary.  Netconf is a management protocol (similar to SNMP) defined in RFC4741.
+Fork of the defacto standard Yuma project since it went proprietary.  Netconf
+is a management protocol (similar to SNMP) defined in RFC4741.
+
+
+Testing with docker
+-------------------
+
+This repository has a `Dockerfile` that can be used to create a container that
+builds openyuma and starts the service. You need a linux with working [docker]
+installation to use it.
+
+To build the container:
+~~~
+docker build -t openyuma .
+~~~
+
+To start it:
+~~~
+docker run -it --rm -p 8300:830 -p 2200:22 --name openyuma openyuma
+~~~
+
+The line above maps openyuma's netconf port to 8300 on the host. You can
+connect to that port with ncclient.
+
+To use *yangcli* as mentioned above, you `docker exec openyuma /bin/bash` to
+enter the running container. Use *admin* as both the user and password.
+


### PR DESCRIPTION
- Add a Dockerfile that creates a container based on ubuntu 14.04, builds
  and installs openyuma on it and allows the user to test the software
  without having to deal with dependencies and versions
- Update README.md with docker usage.
- .travis.yml: travis CI configuration that builds the container and
  uses ncclient to get a config with netconf.

Maybe promote README to README.md?
By activating travis you can also add the "build passing" badge to README.md